### PR TITLE
bugfix: Update Bookmarks with Singer Utils Package

### DIFF
--- a/tap_maestroqa/__init__.py
+++ b/tap_maestroqa/__init__.py
@@ -9,8 +9,7 @@ from singer.schema import Schema
 from .sync import sync
 
 
-REQUIRED_CONFIG_KEYS = ['api_token']
-STATE = {}
+REQUIRED_CONFIG_KEYS = ['api_token', 'start_date']
 LOGGER = singer.get_logger()
 
 

--- a/tap_maestroqa/sync.py
+++ b/tap_maestroqa/sync.py
@@ -101,6 +101,7 @@ def process_file(stream, state, config, file_url):
             bookmark = state['bookmarks'][stream.tap_stream_id]['date_graded']
         else:
             bookmark = config['start_date']
+            state = {}
 
         for row in reader:
             record = {}

--- a/tap_maestroqa/sync.py
+++ b/tap_maestroqa/sync.py
@@ -54,10 +54,7 @@ def transform_value(key, value):
 
 def get_file(client, stream, config, state=None):
 
-    if state:
-        start_date = state['bookmarks'][stream.tap_stream_id]['date_graded']
-    else:
-        start_date = config['start_date']
+    start_date = singer.get_bookmark(state, stream.tap_stream_id, 'date_graded') or config['start_date']
     end_date = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
     params = {
         'startDate': start_date,
@@ -97,11 +94,7 @@ def process_file(stream, state, config, file_url):
             key_properties=stream.key_properties,
         )
 
-        if state:
-            bookmark = state['bookmarks'][stream.tap_stream_id]['date_graded']
-        else:
-            bookmark = config['start_date']
-            state = {}
+        bookmark = singer.get_bookmark(state, stream.tap_stream_id, 'date_graded') or config['start_date']
 
         for row in reader:
             record = {}
@@ -112,7 +105,7 @@ def process_file(stream, state, config, file_url):
                 singer.write_record(stream.tap_stream_id, record)
                 new_bookmark = transform_date(row['date_graded'])
                 if new_bookmark > bookmark:
-                    state['bookmarks'][stream.tap_stream_id]['date_graded'] = new_bookmark
+                    state = singer.write_bookmark(state, stream.tap_stream_id, 'date_graded', new_bookmark)
                     singer.write_state(state)
 
 


### PR DESCRIPTION
Someone in the [Meltano community slack](https://meltano.slack.com/archives/C01TCRBBJD7/p1664207537554719) raised a bug with this tap related to a key error when accessing the bookmarks. I noticed that the state dict/bookmarks were being edited directly which was causing the issue and theres a nice singer utility to get/set bookmark values already. So I implemented that in exchange. I think if you always provide state with bookmarks present then this wouldnt throw an error but on the first run with no state it looks like it does. Although I dont have maestro qa api keys to test it myself, these changes seemed to resolve the problem for the community member.

Also start_date wasnt a required config key but if you dont have state then this would fail is start_date is missing. Personally I'd consider that a requirement then.

@kyuhanpathlight @k3llymariee What do you think? (I saw you were the last commiters)